### PR TITLE
Circleci project setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/ruby:3.1.0
+      - image: cimg/ruby:3.2.2
     executor: ruby/default
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
                                                       
                   # Adding Rule SSH to Your Security Group
                   echo Allowing CircleCI Build to access port 443 from IP $IP to the security group $GROUPID
-                  aws ec2 authorize-security-group-ingress --group-id $GROUPID --ip-permissions '[{"IpProtocol": "tcp", "FromPort": 443, "ToPort": 443, "IpRanges": [{"CidrIp": "'$LATEST_IP/32'", "Description": "'CircleCI Build'"}]}]'                 
+                  aws ec2 authorize-security-group-ingress --group-id $GROUPID --ip-permissions '[{"IpProtocol": "tcp", "FromPort": 443, "ToPort": 443, "IpRanges": [{"CidrIp": "'$LATEST_IP/32'", "Description": "'CircleCI_Build'"}]}]'                 
       - run:
           name: Move build artifacts to staging server
           command: scp -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - run:
           name: Install Python
-          command: sudo apt-get update && sudo apt-get install -y python3 && alias python="python3" && alias pip="pip3"
+          command: sudo apt-get update && sudo apt-get install -y python3 python-is-python3 
       - add_ssh_keys:
           fingerprints:
           - "9a:29:68:ac:a9:9f:56:3b:87:1a:b5:e8:f7:9c:a5:71"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - run:
           name: Install Python
-          command: apt-get update && apt-get install -y python3
+          command: sudo apt-get update && sudo apt-get install -y python3
       - add_ssh_keys:
           fingerprints:
           - "9a:29:68:ac:a9:9f:56:3b:87:1a:b5:e8:f7:9c:a5:71"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
       - run:
           name: Build static site with Jekyll
           command: bundle exec jekyll build
+      - aws-cli/setup
       - run:
               name: AWS whitelist add CircleCI IP
               command: |
@@ -44,10 +45,11 @@ jobs:
 
                   GROUPID=sg-e9bc309e
                   [[ -n "${GROUPID}" ]] || (echo "Could not determine Security Group ID" && exit 0);
+                  PORT=443
                                                       
                   # Adding Rule SSH to Your Security Group
                   echo Allowing CircleCI Build to access port $PORT from IP $IP to the security group $GROUPID
-                  aws ec2 authorize-security-group-ingress --group-id $GROUPID --ip-permissions '[{"IpProtocol": "tcp", "FromPort": 443, "ToPort": 443, "IpRanges": [{"CidrIp": "'$LATEST_IP/32'", "Description": "CircleCI Build"}]}]'                 
+                  aws ec2 authorize-security-group-ingress --group-id $GROUPID --ip-permissions '[{"IpProtocol": "tcp", "FromPort": $PORT, "ToPort": $PORT, "IpRanges": [{"CidrIp": "'$LATEST_IP/32'", "Description": "'CircleCI Build'"}]}]'                 
       - run:
           name: Move build artifacts to staging server
           command: scp -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ jobs:
           command: bundle exec jekyll build
       - aws-white-list-circleci-ip/add:
           description: "CircleCI Build"
-          port: 22
           tag-key: "deployment"
           tag-value: "CircleCI"
       - run:
@@ -41,7 +40,6 @@ jobs:
           command: scp -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit
       - aws-white-list-circleci-ip/remove:
           description: "CircleCI Build"
-          port: 22
           tag-key: "deployment"
           tag-value: "CircleCI"
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - run:
           name: Install Python
-          command: sudo apt-get update && sudo apt-get install -y python3
+          command: sudo apt-get update && sudo apt-get install -y python
       - add_ssh_keys:
           fingerprints:
           - "9a:29:68:ac:a9:9f:56:3b:87:1a:b5:e8:f7:9c:a5:71"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/configuration-reference
+version: 2.1
+
+# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
+# See: https://circleci.com/docs/orb-intro/
+orbs:
+  ruby: circleci/ruby@2.0.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/configuration-reference/#jobs
+jobs:
+  build:
+    docker:
+      - image: cimg/ruby:3.1.0
+    executor: ruby/default
+    steps:
+      - checkout
+      - run:
+          name: Which bundler?
+          command: bundle -v
+      - ruby/install-deps
+      - run:
+          name: Build static site with Jekyll
+          command: bundle exec jekyll build
+
+# Orchestrate jobs using workflows
+# See: https://circleci.com/docs/configuration-reference/#workflows
+workflows:
+  sample: # This is the name of the workflow, feel free to change it to better match your workflow.
+    # Inside the workflow, you define the jobs you want to run.
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ version: 2.1
 # See: https://circleci.com/docs/orb-intro/
 orbs:
   ruby: circleci/ruby@2.0.1
+  python: circleci/python@2.0.3
   aws-white-list-circleci-ip: configure/aws-white-list-circleci-ip@1.0.1
 
 # Define a job to be invoked later in a workflow.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ version: 2.1
 # See: https://circleci.com/docs/orb-intro/
 orbs:
   ruby: circleci/ruby@2.0.1
-  python: circleci/python@2.0.3
   aws-white-list-circleci-ip: configure/aws-white-list-circleci-ip@1.0.1
 
 # Define a job to be invoked later in a workflow.
@@ -17,14 +16,12 @@ jobs:
       - image: cimg/ruby:3.2.2
     executor: ruby/default
     steps:
+      - run:
+          name: Install Python
+          command: apt-get update && apt-get install -y python3
       - add_ssh_keys:
           fingerprints:
           - "9a:29:68:ac:a9:9f:56:3b:87:1a:b5:e8:f7:9c:a5:71"
-      - aws-white-list-circleci-ip/add:
-          description: "CircleCI Build"
-          port: 22
-          tag-key: "deployment"
-          tag-value: "CircleCI"
       - checkout
       - run:
           name: Which bundler?
@@ -33,15 +30,25 @@ jobs:
       - run:
           name: Build static site with Jekyll
           command: bundle exec jekyll build
+      - aws-white-list-circleci-ip/add:
+          description: "CircleCI Build"
+          port: 22
+          tag-key: "deployment"
+          tag-value: "CircleCI"
       - run:
           name: Move build artifacts to staging server
           command: scp -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit
+      - aws-white-list-circleci-ip/remove:
+          description: "CircleCI Build"
+          port: 22
+          tag-key: "deployment"
+          tag-value: "CircleCI"
       
 
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/configuration-reference/#workflows
 workflows:
-  sample: # This is the name of the workflow, feel free to change it to better match your workflow.
+  staging-build-deploy: # This is the name of the workflow, feel free to change it to better match your workflow.
     # Inside the workflow, you define the jobs you want to run.
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@2.0.1
   aws-cli: circleci/aws-cli@4.0.0
-  aws-white-list-circleci-ip: configure/aws-white-list-circleci-ip@1.0.1
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/configuration-reference/#jobs
@@ -31,17 +30,27 @@ jobs:
       - run:
           name: Build static site with Jekyll
           command: bundle exec jekyll build
-      - aws-white-list-circleci-ip/add:
-          description: "CircleCI Build"
-          tag-key: "deployment"
-          tag-value: "CircleCI"
+      - run:
+              name: AWS whitelist add CircleCI IP
+              command: |
+                  
+                  # Get the public ip address
+                  LATEST_IP=$(wget -qO- http://checkip.amazonaws.com)
+                  IP="${IP-$LATEST_IP}"
+                  if [[ "${IP}" == "" ]]; then
+                    echo "Could not find your public IP"
+                    exit 1
+                  fi
+
+                  GROUPID=sg-e9bc309e
+                  [[ -n "${GROUPID}" ]] || (echo "Could not determine Security Group ID" && exit 0);
+                                                      
+                  # Adding Rule SSH to Your Security Group
+                  echo Allowing CircleCI Build to access port $PORT from IP $IP to the security group $GROUPID
+                  aws ec2 authorize-security-group-ingress --group-id $GROUPID --ip-permissions '[{"IpProtocol": "tcp", "FromPort": 443, "ToPort": 443, "IpRanges": [{"CidrIp": "'$LATEST_IP/32'", "Description": "CircleCI Build"}]}]'                 
       - run:
           name: Move build artifacts to staging server
           command: scp -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit
-      - aws-white-list-circleci-ip/remove:
-          description: "CircleCI Build"
-          tag-key: "deployment"
-          tag-value: "CircleCI"
       
 
 # Orchestrate jobs using workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,9 @@ jobs:
       - run:
           name: Build static site with Jekyll
           command: bundle exec jekyll build
-      - run:
-          name: Move build artifacts to staging server
-          command: scp -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit
+      # - run:
+          # name: Move build artifacts to staging server
+          # command: scp -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit
       
 
 # Orchestrate jobs using workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,6 @@ jobs:
       - run:
           name: Install Python
           command: sudo apt-get update && sudo apt-get install -y python3 python-is-python3 python3.10-venv
-      - aws-cli/setup:
-          profile_name: TODO
       - add_ssh_keys:
           fingerprints:
           - "9a:29:68:ac:a9:9f:56:3b:87:1a:b5:e8:f7:9c:a5:71"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,11 +45,10 @@ jobs:
 
                   GROUPID=sg-e9bc309e
                   [[ -n "${GROUPID}" ]] || (echo "Could not determine Security Group ID" && exit 0);
-                  PORT=443
                                                       
                   # Adding Rule SSH to Your Security Group
-                  echo Allowing CircleCI Build to access port $PORT from IP $IP to the security group $GROUPID
-                  aws ec2 authorize-security-group-ingress --group-id $GROUPID --ip-permissions '[{"IpProtocol": "tcp", "FromPort": $PORT, "ToPort": $PORT, "IpRanges": [{"CidrIp": "'$LATEST_IP/32'", "Description": "'CircleCI Build'"}]}]'                 
+                  echo Allowing CircleCI Build to access port 443 from IP $IP to the security group $GROUPID
+                  aws ec2 authorize-security-group-ingress --group-id $GROUPID --ip-permissions '[{"IpProtocol": "tcp", "FromPort": 443, "ToPort": 443, "IpRanges": [{"CidrIp": "'$LATEST_IP/32'", "Description": "'CircleCI Build'"}]}]'                 
       - run:
           name: Move build artifacts to staging server
           command: scp -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ version: 2.1
 # See: https://circleci.com/docs/orb-intro/
 orbs:
   ruby: circleci/ruby@2.0.1
+  aws-cli: circleci/aws-cli@4.0.0
   aws-white-list-circleci-ip: configure/aws-white-list-circleci-ip@1.0.1
 
 # Define a job to be invoked later in a workflow.
@@ -19,6 +20,8 @@ jobs:
       - run:
           name: Install Python
           command: sudo apt-get update && sudo apt-get install -y python3 python-is-python3 python3.10-venv
+      - aws-cli/setup:
+          profile_name: TODO
       - add_ssh_keys:
           fingerprints:
           - "9a:29:68:ac:a9:9f:56:3b:87:1a:b5:e8:f7:9c:a5:71"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ orbs:
 # See: https://circleci.com/docs/configuration-reference/#jobs
 jobs:
   build:
+    circleci_ip_ranges: true
     docker:
       - image: cimg/ruby:3.2.2
     executor: ruby/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,11 @@ jobs:
       - run:
           name: Build static site with Jekyll
           command: bundle exec jekyll build
+      # - add_ssh_keys: (TODO)
+      - run:
+          name: Move build artifacts to staging server
+          command: rsync -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit
+      
 
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/configuration-reference/#workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ orbs:
 # See: https://circleci.com/docs/configuration-reference/#jobs
 jobs:
   build:
-    circleci_ip_ranges: true
     docker:
       - image: cimg/ruby:3.2.2
     executor: ruby/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ jobs:
       - image: cimg/ruby:3.2.2
     executor: ruby/default
     steps:
+      - add_ssh_keys:
+          fingerprints:
+          - "9a:29:68:ac:a9:9f:56:3b:87:1a:b5:e8:f7:9c:a5:71"
       - checkout
       - run:
           name: Which bundler?
@@ -23,7 +26,6 @@ jobs:
       - run:
           name: Build static site with Jekyll
           command: bundle exec jekyll build
-      # - add_ssh_keys: (TODO)
       - run:
           name: Move build artifacts to staging server
           command: rsync -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ orbs:
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/configuration-reference/#jobs
 jobs:
-  build:
+  build_and_deploy:
     docker:
       - image: cimg/ruby:3.2.2
     executor: ruby/default
@@ -72,4 +72,4 @@ workflows:
   staging-build-deploy: # This is the name of the workflow, feel free to change it to better match your workflow.
     # Inside the workflow, you define the jobs you want to run.
     jobs:
-      - build
+      - build_and_deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,12 +48,29 @@ jobs:
                   [[ -n "${GROUPID}" ]] || (echo "Could not determine Security Group ID" && exit 0);
                                                       
                   # Adding Rule SSH to Your Security Group
-                  echo Allowing CircleCI Build to access port 22 from IP $IP to the security group $GROUPID
+                  echo Allowing CircleCI_Build to access port 22 from IP $IP to the security group $GROUPID
                   aws ec2 authorize-security-group-ingress --group-id $GROUPID --ip-permissions '[{"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "IpRanges": [{"CidrIp": "'$LATEST_IP/32'", "Description": "'CircleCI_Build'"}]}]'                 
       - run:
           name: Move build artifacts to staging server
           command: scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit
-      
+      - run:
+              name: AWS whitelist remove CircleCI IP
+              command: |
+
+                  # Get the public ip address
+                  LATEST_IP=$(wget -qO- http://checkip.amazonaws.com)
+                  IP=${IP-$LATEST_IP}
+                  [[ -n "$IP" ]] || (echo "Could not find your public IP" && exit 1);
+                  
+                  GROUPID=sg-e9bc309e
+                  [[ -n "$GROUPID" ]] || (echo "Could not determine Security Group ID" && exit 1);
+
+
+                  echo "Removing CircleCI_Build access from IP $IP to the security group $GROUPID"
+
+                  # Delete IP rules matching port
+                  aws ec2 revoke-security-group-ingress --group-id $GROUPID --ip-permissions '[{"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "IpRanges": [{"CidrIp": "'$LATEST_IP/32'", "Description": "'CircleCI_Build'"}]}]'
+              when: always
 
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/configuration-reference/#workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,8 @@ jobs:
                   [[ -n "${GROUPID}" ]] || (echo "Could not determine Security Group ID" && exit 0);
                                                       
                   # Adding Rule SSH to Your Security Group
-                  echo Allowing CircleCI Build to access port 443 from IP $IP to the security group $GROUPID
-                  aws ec2 authorize-security-group-ingress --group-id $GROUPID --ip-permissions '[{"IpProtocol": "tcp", "FromPort": 443, "ToPort": 443, "IpRanges": [{"CidrIp": "'$LATEST_IP/32'", "Description": "'CircleCI_Build'"}]}]'                 
+                  echo Allowing CircleCI Build to access port 22 from IP $IP to the security group $GROUPID
+                  aws ec2 authorize-security-group-ingress --group-id $GROUPID --ip-permissions '[{"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "IpRanges": [{"CidrIp": "'$LATEST_IP/32'", "Description": "'CircleCI_Build'"}]}]'                 
       - run:
           name: Move build artifacts to staging server
           command: scp -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - run:
           name: Install Python
-          command: sudo apt-get update && sudo apt-get install -y python3 python-is-python3 
+          command: sudo apt-get update && sudo apt-get install -y python3 python-is-python3 python3.10-venv
       - add_ssh_keys:
           fingerprints:
           - "9a:29:68:ac:a9:9f:56:3b:87:1a:b5:e8:f7:9c:a5:71"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
                   aws ec2 authorize-security-group-ingress --group-id $GROUPID --ip-permissions '[{"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "IpRanges": [{"CidrIp": "'$LATEST_IP/32'", "Description": "'CircleCI_Build'"}]}]'                 
       - run:
           name: Move build artifacts to staging server
-          command: scp -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit
+          command: scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit
       
 
 # Orchestrate jobs using workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - run:
           name: Install Python
-          command: sudo apt-get update && sudo apt-get install -y python
+          command: sudo apt-get update && sudo apt-get install -y python3 && alias python="python3" && alias pip="pip3"
       - add_ssh_keys:
           fingerprints:
           - "9a:29:68:ac:a9:9f:56:3b:87:1a:b5:e8:f7:9c:a5:71"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,17 +16,11 @@ jobs:
       - image: cimg/ruby:3.2.2
     executor: ruby/default
     steps:
-      - run:
-          name: Install Python
-          command: sudo apt-get update && sudo apt-get install -y python3 python-is-python3 python3.10-venv
       - add_ssh_keys:
           fingerprints:
           - "9a:29:68:ac:a9:9f:56:3b:87:1a:b5:e8:f7:9c:a5:71"
           - "c7:89:8c:09:3e:6f:f3:c8:bd:6d:16:e4:60:13:f0:65"
       - checkout
-      - run:
-          name: Which bundler?
-          command: bundle -v
       - ruby/install-deps
       - run:
           name: Build static site with Jekyll

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ version: 2.1
 # See: https://circleci.com/docs/orb-intro/
 orbs:
   ruby: circleci/ruby@2.0.1
+  aws-white-list-circleci-ip: configure/aws-white-list-circleci-ip@1.0.1
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/configuration-reference/#jobs
@@ -18,6 +19,11 @@ jobs:
       - add_ssh_keys:
           fingerprints:
           - "9a:29:68:ac:a9:9f:56:3b:87:1a:b5:e8:f7:9c:a5:71"
+      - aws-white-list-circleci-ip/add:
+          description: "CircleCI Build"
+          port: 22
+          tag-key: "deployment"
+          tag-value: "CircleCI"
       - checkout
       - run:
           name: Which bundler?
@@ -26,9 +32,9 @@ jobs:
       - run:
           name: Build static site with Jekyll
           command: bundle exec jekyll build
-      # - run:
-          # name: Move build artifacts to staging server
-          # command: scp -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit
+      - run:
+          name: Move build artifacts to staging server
+          command: scp -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit
       
 
 # Orchestrate jobs using workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           command: bundle exec jekyll build
       - run:
           name: Move build artifacts to staging server
-          command: rsync -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit
+          command: scp -r _site/* perfect-fit@prep.mapc.org:/var/www/perfect-fit
       
 
 # Orchestrate jobs using workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
           - "9a:29:68:ac:a9:9f:56:3b:87:1a:b5:e8:f7:9c:a5:71"
+          - "c7:89:8c:09:3e:6f:f3:c8:bd:6d:16:e4:60:13:f0:65"
       - checkout
       - run:
           name: Which bundler?


### PR DESCRIPTION
Initial CircleCI config for staging deploys of this project.

Uses `jekyll` to build the static site, then `scp` to copy it up to the staging server. Uses `aws-cli` to temporarily create an IP-whitelisting rule in AWS for the purposes of deployment.
